### PR TITLE
fix typo

### DIFF
--- a/env/main/files/galaxy/config/job_resource_params_conf.xml
+++ b/env/main/files/galaxy/config/job_resource_params_conf.xml
@@ -14,7 +14,7 @@
         <option value="jetstream_multi">Jetstream</option>
         <option value="bridges_normal">PSC Bridges</option>
         <option value="slurm_multi_development">Galaxy cluster test/development</option>
-        <option value="pular_bridges_development">PSC Bridges test/development</option>
+        <option value="pulsar_bridges_development">PSC Bridges test/development</option>
     </param>
     <param label="Compute Resource" name="stampede_compute_resource" type="select" help="Need help selecting a compute resource? Options and limits are explained in detail &lt;a href='https://galaxyproject.org/main/' target='_blank'&gt;in the Galaxy Hub&lt;/a&gt;">
         <option value="stampede_normal">TACC Stampede (default)</option>


### PR DESCRIPTION
Should this have a corresponding entry in the multi_dynamic_walltime rules?

This is also present in config for Test.