### PR TITLE
Implement reporting job runs to xsede API

### DIFF
--- a/env/common/templates/galaxy/files/run_xsede_report.sh.j2
+++ b/env/common/templates/galaxy/files/run_xsede_report.sh.j2
@@ -1,0 +1,13 @@
+#!/bin/sh
+##
+## This file is maintained by Ansible - CHANGES WILL BE OVERWRITTEN
+##
+
+activate="{{ galaxy_venv_dir }}/activate"
+echo "Activating virtualenv with $activate"
+. "$activate"
+
+PYTHONPATH={{ galaxy_server_dir }}/lib
+
+python {{ galaxy_root }}/var/xsede_report/xsede_report.py -c {{ galaxy_config_file }} -t 24 -g {{ galaxy_instance_hostname }} 2>&1 | tee -a {{ galaxy_log_dir }}/xsede_report.log
+

--- a/env/common/templates/galaxy/files/xsede_report.py.j2
+++ b/env/common/templates/galaxy/files/xsede_report.py.j2
@@ -28,7 +28,7 @@ OFFSET_FILE_NAME = "xsede_retry_offset"
 
 # The following values are templated by Ansible
 OFFSET_FILE_PATH = "{{ galaxy_root }}/bin/" + OFFSET_FILE_NAME
-GALAXY_XSEDE_APIKEY = "{{ galaxy_xsede_apikey  }}"
+GALAXY_XSEDE_APIKEY = "{{ galaxy_xsede_apikey }}"
 
 JOBS_SQL = """
     SELECT job.id,
@@ -62,7 +62,7 @@ def parse_arguments():
                         type=int,
                         default=24,
                         help='How many hours back to query.')
-    parser.add_argument('-g', '--galaxy_name',
+    parser.add_argument('-g', '--galaxy-name',
                         type=str,
                         default=None,
                         help='What Galaxy is reporting, choices: main|test.')

--- a/env/common/templates/galaxy/files/xsede_report.py.j2
+++ b/env/common/templates/galaxy/files/xsede_report.py.j2
@@ -1,0 +1,179 @@
+#!/usr/bin/env  python
+"""
+!! This file is templated by Ansible, manual changes will have no effect.
+
+Report jobs to XSEDE API. Run with CRON and in Galaxy venv.
+"""
+from __future__ import print_function
+
+import argparse
+import os
+import sys
+
+import psycopg2
+import requests
+
+galaxy_root = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+sys.path.insert(1, os.path.join(galaxy_root, 'lib'))
+
+import galaxy.config
+from galaxy.util.script import app_properties_from_args, populate_config_args
+
+DESTINATION_MAPPING = {
+    "stampede_" : "stampede2.tacc.xsede",
+    "bridges_" : "bridges-large.psc.xsede"
+}
+SERVER_NAMES = ["test", "main"]
+OFFSET_FILE_NAME = "xsede_retry_offset"
+
+# The following values are templated by Ansible
+OFFSET_FILE_PATH = "{{ galaxy_root }}/bin/" + OFFSET_FILE_NAME
+GALAXY_XSEDE_APIKEY = "{{ galaxy_xsede_apikey  }}"
+
+JOBS_SQL = """
+    SELECT job.id,
+        job.create_time AT TIME ZONE 'UTC' AS create_time,
+        galaxy_user.username,
+        job.destination_id
+    FROM job,
+        galaxy_user
+    WHERE job.user_id = galaxy_user.id
+    AND job.job_runner_external_id != ''
+    AND (job.destination_id LIKE 'stampede_%' OR job.destination_id LIKE 'bridges_%')
+    AND job.id IN
+        (SELECT job_id
+        FROM job_state_history
+        WHERE (job_state_history.state = 'ok'
+                OR job_state_history.state = 'error')
+        AND job_state_history.job_id = job.id
+        AND job_state_history.create_time > (now() AT TIME ZONE 'UTC' - '${} hours'::interval) )
+    ORDER BY id DESC
+"""
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(description='generate and report XSEDE statistics')
+    populate_config_args(parser)
+    parser.add_argument('-d', '--debug',
+                        action='store_true',
+                        default=False,
+                        help='Print extra info')
+    parser.add_argument('-t', '--offset',
+                        type=int,
+                        default=24,
+                        help='How many hours back to query.')
+    parser.add_argument('-g', '--galaxy_name',
+                        type=str,
+                        default=None,
+                        help='What Galaxy is reporting, choices: main|test.')
+    args = parser.parse_args()
+    if args.galaxy_name not in SERVER_NAMES:
+        raise Exception("Unknown server name. Specify using -g.", args.galaxy_name)
+    app_properties = app_properties_from_args(args)
+    config = galaxy.config.Configuration(**app_properties)
+    # print(config.database_connection)
+    args.dburi = config.database_connection
+    args.current_offset = get_current_offset(args.offset)
+    if args.debug:
+        print('Full options:')
+        for i in vars(args).items():
+            print('%s: %s' % i)
+    return args
+
+
+def query(current_offset, dburi, debug, **kwargs):
+    pc = psycopg2.connect(dburi)
+    cur = pc.cursor()
+    sql = JOBS_SQL.format(current_offset)
+    cur.execute(sql)
+    if debug:
+        print('Executed:')
+        print(cur.query)
+    print('Query returned %d rows' % cur.rowcount)
+    rows = cur.fetchall()
+    cur.close()
+    return rows
+
+
+def submit(row, args):
+    xsede_job_id, xsede_submit_time, username, xsede_resource = format_data(row[0], row[1], row[2], row[3], args)
+    xsede_url = "https://xsede-xdcdb-api.xsede.org/gateway/v2/job_attributes"
+    xsede_data = {
+        "gatewayuser": username,
+        "xsederesourcename": xsede_resource,
+        "jobid": xsede_job_id,
+        "submittime": xsede_submit_time,
+        "apikey": GALAXY_XSEDE_APIKEY
+    }
+    if args.debug:
+        xsede_data["debug"] = True
+    return requests.post(xsede_url, data=xsede_data)
+
+
+def format_data(job_id, submit_time, username, resource, args):
+    xsede_submit_time = submit_time.strftime("%d-%m-%y %H:%M %z")
+    xsede_job_id = args.galaxy_name + "_" + str(job_id)
+    for key in DESTINATION_MAPPING:
+        if resource.startswith(key):
+            xsede_resource = DESTINATION_MAPPING[key]
+            break
+    return xsede_job_id, xsede_submit_time, username, xsede_resource
+
+
+def get_current_offset(given_offset):
+    """
+    Calculate current query offset by adding the value in
+    offset file to the offset given as an argument.
+    """
+    if not os.path.exists(OFFSET_FILE_PATH):
+        current_offset = given_offset
+    else:
+        with open(OFFSET_FILE_PATH, "r") as f:
+            line = f.readline()
+            offset = 0
+            if line != "":
+                try:
+                    offset = int(line)
+                except Exception:
+                    print("Unable to parse offset file, ignoring.")
+            current_offset = offset + given_offset
+    return current_offset
+
+
+def write_current_offset(current_offset):
+    """
+    Store the current offset in the file.
+    """
+    with open(OFFSET_FILE_PATH, "w") as f:
+        f.write(str(current_offset))
+
+
+def main():
+    args = parse_arguments()
+    rows = query(**vars(args))
+    print("Sending data to XSEDE.")
+    reported_jobs = 0
+    for row in rows:
+        response = None
+        try:
+            response = submit(row, args)
+            assert response.status_code in [200]
+            print("OK " + str(format_data(row[0], row[1], row[2], row[3], args)))
+            reported_jobs += 1
+        except Exception as e:
+            print("Breaking the submission process and increasing offset.")
+            write_current_offset(args.current_offset)
+            print("Submission of the object below failed:")
+            print(response.headers)
+            print(response.text)
+            print("Full script options:")
+            for i in vars(args).items():
+                print('%s: %s' % i)
+            raise e
+    print("Succesfully reported %s jobs out of %s." % (reported_jobs, len(rows)))
+    if reported_jobs == len(rows):
+        write_current_offset(0)
+
+
+if __name__ == '__main__':
+    main()

--- a/env/common/templates/galaxy/files/xsede_report.py.j2
+++ b/env/common/templates/galaxy/files/xsede_report.py.j2
@@ -27,7 +27,7 @@ SERVER_NAMES = ["test", "main"]
 OFFSET_FILE_NAME = "xsede_retry_offset"
 
 # The following values are templated by Ansible
-OFFSET_FILE_PATH = "{{ galaxy_root }}/bin/" + OFFSET_FILE_NAME
+OFFSET_FILE_PATH = "{{ galaxy_root }}/var/xsede_report/" + OFFSET_FILE_NAME
 GALAXY_XSEDE_APIKEY = "{{ galaxy_xsede_apikey }}"
 
 JOBS_SQL = """

--- a/env/common/templates/galaxy/files/xsede_report.py.j2
+++ b/env/common/templates/galaxy/files/xsede_report.py.j2
@@ -5,8 +5,8 @@
 Report jobs to XSEDE API. Run with CRON and in Galaxy venv.
 
 Example of querying past 24h of jobs that require reporting for the
-Test Galaxy in debug mode (nothing actually saved on the server side).
-python scripts/xsede_report.py -c config/galaxy.yml -t 24 -g test.galaxyproject.org -d
+Test Galaxy in debug mode and dry-run mode (nothing actually saved on the server side).
+python scripts/xsede_report.py -c config/galaxy.yml -t 24 -g test.galaxyproject.org -r -d
 
 Example of production usage:
 python scripts/xsede_report.py -c config/galaxy.yml -t 24 -g usegalaxy.org

--- a/env/common/templates/galaxy/files/xsede_report.py.j2
+++ b/env/common/templates/galaxy/files/xsede_report.py.j2
@@ -3,18 +3,21 @@
 !! This file is templated by Ansible, manual changes will have no effect.
 
 Report jobs to XSEDE API. Run with CRON and in Galaxy venv.
+
+Example of querying past 24h of jobs that require reporting for the
+Test Galaxy in debug mode (nothing actually saved on the server side).
+python scripts/xsede_report.py -c config/galaxy.yml -t 24 -g test.galaxyproject.org -d
+
+Example of production usage:
+python scripts/xsede_report.py -c config/galaxy.yml -t 24 -g usegalaxy.org
 """
 from __future__ import print_function
 
 import argparse
 import os
-import sys
 
 import psycopg2
 import requests
-
-galaxy_root = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
-sys.path.insert(1, os.path.join(galaxy_root, 'lib'))
 
 import galaxy.config
 from galaxy.util.script import app_properties_from_args, populate_config_args
@@ -23,7 +26,6 @@ DESTINATION_MAPPING = {
     "stampede_" : "stampede2.tacc.xsede",
     "bridges_" : "bridges-large.psc.xsede"
 }
-SERVER_NAMES = ["test", "main"]
 OFFSET_FILE_NAME = "xsede_retry_offset"
 
 # The following values are templated by Ansible
@@ -65,10 +67,12 @@ def parse_arguments():
     parser.add_argument('-g', '--galaxy-name',
                         type=str,
                         default=None,
-                        help='What Galaxy is reporting, choices: main|test.')
+                        help='Which Galaxy is reporting. Prefix for job_ids')
+    parser.add_argument('-r', '--dry-run',
+                        action='store_true',
+                        default=False,
+                        help='Do not actually save the submissions on the server side.')
     args = parser.parse_args()
-    if args.galaxy_name not in SERVER_NAMES:
-        raise Exception("Unknown server name. Specify using -g.", args.galaxy_name)
     app_properties = app_properties_from_args(args)
     config = galaxy.config.Configuration(**app_properties)
     # print(config.database_connection)
@@ -105,7 +109,8 @@ def submit(row, args):
         "submittime": xsede_submit_time,
         "apikey": GALAXY_XSEDE_APIKEY
     }
-    if args.debug:
+    if args.dry_run:
+        # Flag that prevents server from saving the submission
         xsede_data["debug"] = True
     return requests.post(xsede_url, data=xsede_data)
 

--- a/env/main/group_vars/galaxymasters.yml
+++ b/env/main/group_vars/galaxymasters.yml
@@ -1,0 +1,7 @@
+---
+
+## used by: XSEDE reporting
+galaxymasters_group_templates:
+  - src: templates/galaxy/files/xsede_report.py.j2
+    dest: "{{ galaxy_root }}/var/xsede_report/xsede_report.py"
+    mode: "0755"

--- a/env/main/group_vars/galaxymasters.yml
+++ b/env/main/group_vars/galaxymasters.yml
@@ -6,5 +6,13 @@ galaxymasters_group_templates:
     dest: "{{ galaxy_root }}/var/xsede_report/xsede_report.py"
     mode: "0755"
   - src: templates/galaxy/files/run_xsede_report.sh.j2
-    dest: "{{ galaxy_root }}/bin/run_xsede_report.sh"
+    dest: "{{ galaxy_root }}/bin/xsede_report"
     mode: "0755"
+    
+galaxymasters_group_crontabs:
+  - id: xsede_report
+    name: Report jobs to XSEDE
+    user: "{{ galaxy_user }}"
+    hour: 0
+    minute: 0
+    job: "{{ galaxy_root }}/bin/run_xsede_report"

--- a/env/main/group_vars/galaxymasters.yml
+++ b/env/main/group_vars/galaxymasters.yml
@@ -5,3 +5,6 @@ galaxymasters_group_templates:
   - src: templates/galaxy/files/xsede_report.py.j2
     dest: "{{ galaxy_root }}/var/xsede_report/xsede_report.py"
     mode: "0755"
+  - src: templates/galaxy/files/run_xsede_report.sh.j2
+    dest: "{{ galaxy_root }}/bin/run_xsede_report.sh"
+    mode: "0755"

--- a/env/main/templates/galaxy/files
+++ b/env/main/templates/galaxy/files
@@ -1,0 +1,1 @@
+../../../common/templates/galaxy/files

--- a/env/test/group_vars/galaxymasters.yml
+++ b/env/test/group_vars/galaxymasters.yml
@@ -1,0 +1,7 @@
+---
+
+## used by: XSEDE reporting
+galaxymasters_group_templates:
+  - src: templates/galaxy/files/xsede_report.py.j2
+    dest: "{{ galaxy_root }}/var/xsede_report/xsede_report.py"
+    mode: "0755"

--- a/env/test/group_vars/galaxymasters.yml
+++ b/env/test/group_vars/galaxymasters.yml
@@ -6,5 +6,13 @@ galaxymasters_group_templates:
     dest: "{{ galaxy_root }}/var/xsede_report/xsede_report.py"
     mode: "0755"
   - src: templates/galaxy/files/run_xsede_report.sh.j2
-    dest: "{{ galaxy_root }}/bin/run_xsede_report.sh"
+    dest: "{{ galaxy_root }}/bin/xsede_report"
     mode: "0755"
+    
+galaxymasters_group_crontabs:
+  - id: xsede_report
+    name: Report jobs to XSEDE
+    user: "{{ galaxy_user }}"
+    hour: 0
+    minute: 0
+    job: "{{ galaxy_root }}/bin/run_xsede_report"

--- a/env/test/group_vars/galaxymasters.yml
+++ b/env/test/group_vars/galaxymasters.yml
@@ -5,3 +5,6 @@ galaxymasters_group_templates:
   - src: templates/galaxy/files/xsede_report.py.j2
     dest: "{{ galaxy_root }}/var/xsede_report/xsede_report.py"
     mode: "0755"
+  - src: templates/galaxy/files/run_xsede_report.sh.j2
+    dest: "{{ galaxy_root }}/bin/run_xsede_report.sh"
+    mode: "0755"

--- a/env/test/templates/galaxy/files
+++ b/env/test/templates/galaxy/files
@@ -1,0 +1,1 @@
+../../../common/templates/galaxy/files


### PR DESCRIPTION
This has been tested locally with the proper API using debug params. I've also included some excessive printing for debugging purposes since I am not sure what we can expect from that API.

Has to be templated with `galaxy_xsede_apikey` and `galaxy_root`

What is missing is integration with our playbook and cron-setup tasks.

Example of querying past 24h of jobs that require reporting for the Test Galaxy in debug mode (nothing actually saved on the server side).
`python scripts/xsede_report.py -c config/galaxy.yml -t 24 -g test -d`

Example of production usage:
`python scripts/xsede_report.py -c config/galaxy.yml -t 24 -g main`

xsede api docs: https://xsede-xdcdb-api.xsede.org/api/gateways 
https://dl.acm.org/citation.cfm?id=3338096
