### PR TITLE
Update tool shed and index repos every ~~hour~~ minute

### DIFF
--- a/env/common/templates/supervisor/toolshed.j2
+++ b/env/common/templates/supervisor/toolshed.j2
@@ -10,7 +10,7 @@ autostart       = true
 autorestart     = true
 startsecs       = 15
 user            = shed
-environment     = HOME="/home/shed",TMPDIR="{{ toolshed_tmpdir }}"
+environment     = HOME="/home/shed",TMPDIR="{{ toolshed_tmpdir }}",PATH="{{ galaxy_venv_dir }}/bin:%(ENV_PATH)s",VIRTUAL_ENV="{{ galaxy_venv_dir }}"
 numprocs        = 1
 stopsignal      = INT
 stdout_logfile  = /var/log/supervisord/{{ galaxy_toolshed_instance_codename }}_uwsgi.stdout.log

--- a/env/toolshed/group_vars/toolshedservers/vars.yml
+++ b/env/toolshed/group_vars/toolshedservers/vars.yml
@@ -134,7 +134,7 @@ galaxy_toolshed_config:
     chmod-socket: 664
     chown-socket: "shed:www-data"
     pythonpath: lib
-    unique-cron: -1 -1 -1 -1 -1 python scripts/tool_shed/build_ts_whoosh_index.py -c config/tool_shed.yml --config-section tool_shed
+    unique-cron: -1 -1 -1 -1 -1 python scripts/tool_shed/build_ts_whoosh_index.py -c {{ galaxy_toolshed_config_file }} --config-section app:main
   "app:main":
     # secrets
 

--- a/env/toolshed/group_vars/toolshedservers/vars.yml
+++ b/env/toolshed/group_vars/toolshedservers/vars.yml
@@ -18,7 +18,10 @@ postgresql_objects_groups:
 
 
 # Tool Shed version
-galaxy_commit_id: 711e536cd566e71dba3d0d017ad675b53e9936da
+galaxy_commit_id: 7f2686c5c7a5afd898217565f1cee58996f9d285
+# currently needed for client artifacts left in the source tree
+galaxy_force_checkout: yes
+
 
 
 # used only here and by the supervisor template
@@ -49,7 +52,6 @@ toolshedservers_group_crontabs:
 galaxy_toolshed_config_admin_users: "{{ vault_galaxy_toolshed_config_admin_users }}"
 galaxy_toolshed_config_id_secret: "{{ vault_galaxy_toolshed_config_id_secret }}"
 galaxy_toolshed_config_sentry_dsn: "{{ vault_galaxy_toolshed_config_sentry_dsn }}"
-
 
 ## used by: other vars in this vars file
 galaxy_toolshed_root: "/srv/toolshed/{{ galaxy_toolshed_instance_codename }}"
@@ -132,6 +134,7 @@ galaxy_toolshed_config:
     chmod-socket: 664
     chown-socket: "shed:www-data"
     pythonpath: lib
+    cron: 0 * * * * python scripts/tool_shed/build_ts_whoosh_index.py -c config/tool_shed.yml --config-section tool_shed
   "app:main":
     # secrets
 

--- a/env/toolshed/group_vars/toolshedservers/vars.yml
+++ b/env/toolshed/group_vars/toolshedservers/vars.yml
@@ -134,7 +134,7 @@ galaxy_toolshed_config:
     chmod-socket: 664
     chown-socket: "shed:www-data"
     pythonpath: lib
-    cron: 0 * * * * python scripts/tool_shed/build_ts_whoosh_index.py -c config/tool_shed.yml --config-section tool_shed
+    unique-cron: -1 -1 -1 -1 -1 python scripts/tool_shed/build_ts_whoosh_index.py -c config/tool_shed.yml --config-section tool_shed
   "app:main":
     # secrets
 

--- a/env/toolshed/group_vars/toolshedservers/vars.yml
+++ b/env/toolshed/group_vars/toolshedservers/vars.yml
@@ -134,7 +134,7 @@ galaxy_toolshed_config:
     chmod-socket: 664
     chown-socket: "shed:www-data"
     pythonpath: lib
-    unique-cron: -1 -1 -1 -1 -1 python scripts/tool_shed/build_ts_whoosh_index.py -c {{ galaxy_toolshed_config_file }} --config-section app:main
+    unique-cron: -1 -1 -1 -1 -1 {{ galaxy_venv_dir }}/bin/python scripts/tool_shed/build_ts_whoosh_index.py -c {{ galaxy_toolshed_config_file }} --config-section app:main
   "app:main":
     # secrets
 


### PR DESCRIPTION
That should make https://github.com/galaxyproject/galaxy/issues/9347 a
little less annoying.

Maybe this should go to `toolshedservers_group_crontabs` instead ? I'm also not sure if we maybe need to indicate which python to use ? Shouldn't there already be a cron entry for this ?
