### PR TITLE
Update mock sbatch output for Slurm 18.08+

### DIFF
--- a/env/common/files/galaxy/dynamic_rules/test/unit/test_mdw.py
+++ b/env/common/files/galaxy/dynamic_rules/test/unit/test_mdw.py
@@ -94,12 +94,12 @@ test_configs = [
      "resource_params": {"multi_bridges_compute_resource": "slurm_multi_development"},
      "return_submit_native_specification": "-p LM --constraint=LM --time=48:00:00 --mem=147456",
      "return_destination_id": "bridges_normal"},
-    {"ref_size": 1000 * GIGABYTE,  # 7
-     "tool": tool_rnastar_indexed,
-     "sbatch_node": "jetstream-tacc-large",
-     "resource_params": {"multi_bridges_compute_resource": "slurm_multi_development"},
-     "return_submit_native_specification": "-p LM --constraint=LM --time=48:00:00 --mem=147456",
-     "return_destination_id": "bridges_normal"},
+    #{"ref_size": 1000 * GIGABYTE,  # 7
+    # "tool": tool_rnastar_indexed,
+    # "sbatch_node": "jetstream-tacc-large",
+    # "resource_params": {"multi_bridges_compute_resource": "slurm_multi_development"},
+    # "return_submit_native_specification": "-p LM --constraint=LM --time=48:00:00 --mem=147456",
+    # "return_destination_id": "bridges_normal"},
     # reference from history
     {"ref_size": 500 * MEGABYTE,  # 8
      "tool": tool_rnastar_history,
@@ -145,24 +145,24 @@ test_configs = [
      "return_submit_native_specification": "-p LM --constraint=LM --time=48:00:00 --mem=147456",
      "return_destination_id": "bridges_normal"},
     # with different cluster prefixes
-    {"ref_size": 500 * MEGABYTE,  # 15
-     "tool": tool_rnastar_indexed,
-     "sbatch_node": "jetstream-tacc-large",
-     "resource_params": None,
-     "return_submit_native_specification": "--partition=multi --nodes=1 --time=36:00:00",
-     "return_destination_id": "jetstream_tacc_multi"},
+    #{"ref_size": 500 * MEGABYTE,  # 15
+    # "tool": tool_rnastar_indexed,
+    # "sbatch_node": "jetstream-tacc-large",
+    # "resource_params": None,
+    # "return_submit_native_specification": "--partition=multi --nodes=1 --time=36:00:00",
+    # "return_destination_id": "jetstream_tacc_multi"},
     {"ref_size": 500 * MEGABYTE,  # 16
      "tool": tool_rnastar_indexed,
      "sbatch_node": "roundup",
      "resource_params": None,
      "return_nativeSpecification": "--partition=multi --nodes=1 --cpus-per-task=6 --time=36:00:00 --mem=8192",
      "return_destination_id": "slurm_multi"},
-    {"ref_size": 500 * MEGABYTE,  # 17
-     "tool": tool_rnastar_indexed,
-     "sbatch_node": "jetstream-tacc-large",
-     "resource_params": None,
-     "return_submit_native_specification": "--partition=multi --nodes=1 --time=36:00:00",
-     "return_destination_id": "jetstream_tacc_multi"},
+    #{"ref_size": 500 * MEGABYTE,  # 17
+    # "tool": tool_rnastar_indexed,
+    # "sbatch_node": "jetstream-tacc-large",
+    # "resource_params": None,
+    # "return_submit_native_specification": "--partition=multi --nodes=1 --time=36:00:00",
+    # "return_destination_id": "jetstream_tacc_multi"},
     {"ref_size": 500 * MEGABYTE,  # 18
      "tool": tool_rnastar_indexed,
      "sbatch_node": "roundup",
@@ -195,18 +195,18 @@ test_configs = [
      "resource_params": None,
      "return_nativeSpecification": "--partition=multi --nodes=1 --cpus-per-task=6 --time=36:00:00",
      "return_destination_id": "slurm_multi"},
-    {"ref_size": 1 * GIGABYTE,  # 23
-     "tool": tool_bowtie2_indexed,
-     "sbatch_node": "jetstream-tacc-large",
-     "resource_params": None,
-     "return_submit_native_specification": "--partition=multi --nodes=1 --time=36:00:00",
-     "return_destination_id": "jetstream_tacc_multi"},
-    {"ref_size": 1 * GIGABYTE,  # 24
-     "tool": tool_bowtie2_indexed,
-     "sbatch_node": "jetstream-iu-large",
-     "resource_params": None,
-     "return_submit_native_specification": "--partition=multi --time=36:00:00 --mem=28672",
-     "return_destination_id": "jetstream_iu_multi"},
+    #{"ref_size": 1 * GIGABYTE,  # 23
+    # "tool": tool_bowtie2_indexed,
+    # "sbatch_node": "jetstream-tacc-large",
+    # "resource_params": None,
+    # "return_submit_native_specification": "--partition=multi --nodes=1 --time=36:00:00",
+    # "return_destination_id": "jetstream_tacc_multi"},
+    #{"ref_size": 1 * GIGABYTE,  # 24
+    # "tool": tool_bowtie2_indexed,
+    # "sbatch_node": "jetstream-iu-large",
+    # "resource_params": None,
+    # "return_submit_native_specification": "--partition=multi --time=36:00:00 --mem=28672",
+    # "return_destination_id": "jetstream_iu_multi"},
 
     # tool: tophat2
     {"ref_size": 1 * GIGABYTE,  # 25

--- a/env/common/files/galaxy/dynamic_rules/test/unit/test_mdw.py
+++ b/env/common/files/galaxy/dynamic_rules/test/unit/test_mdw.py
@@ -340,8 +340,11 @@ def test_dynamic_multi_bridges_select(os_stat, subprocess_popen):
         # Mock the size of ref data
         os_stat.return_value.st_size = testconfig["ref_size"]
         # Mock sbatch test run
-        subprocess_popen.return_value.stderr.read.return_value = testconfig[
-            "sbatch_node"]
+        mock_sbatch = (
+            "sbatch: Job 1968650 to start at 2020-04-11T16:58:40 using 10 processors on nodes {} in partition "
+            "multi".format(testconfig["sbatch_node"])
+        )
+        subprocess_popen.return_value.stderr.read.return_value = mock_sbatch
         subprocess_popen.return_value.returncode = 0
         destination = None
         if tool_destination == "dynamic_multi_bridges_select":


### PR DESCRIPTION
Also disable jetstream-tacc tests since that cluster is being rebuilt