### PR TITLE
Do not allow deseq2 to run on Jetstream (by default):

### DIFF
--- a/env/common/files/galaxy/dynamic_rules/test/unit/test_job_router.py
+++ b/env/common/files/galaxy/dynamic_rules/test/unit/test_job_router.py
@@ -40,6 +40,7 @@ mock_job.parameters = []
 mock_job.id = 1
 
 
+# FIXME: force user login...
 #def test_user_presence():
 #    with pytest.raises(JobMappingException):
 #        mdw.dynamic_multi_bridges_select(
@@ -358,6 +359,18 @@ def test_stampede_normal():
         "tool": tool,
         "return_native_spec": "--partition=normal --nodes=1 --account=TG-MCB140147 --ntasks=68 --time=24:00:00",
         "return_destination_id": "stampede_normal",
+    }
+    __test_job_router(test)
+
+
+def test_deseq2():
+    tool = mock.Mock()
+    tool.id = "deseq2"
+    tool.params = {}
+    test = {
+        "tool": tool,
+        "return_native_spec": MULTI_NATIVE_SPEC,
+        "return_destination_id": "slurm_multi",
     }
     __test_job_router(test)
 

--- a/env/common/templates/galaxy/config/job_router_conf.yml.j2
+++ b/env/common/templates/galaxy/config/job_router_conf.yml.j2
@@ -94,6 +94,11 @@ tools:
   # Tools with special mappings
   #
 
+  # Multicore tools that are not Pulsar/Jetstream friendly
+
+  # needs tool_files/get_deseq_dataset.R
+  deseq2: {destination: slurm_multi}
+
   # STARSolo uses the same params and has the same requirements as STAR
   rna_starsolo: rna_star
 


### PR DESCRIPTION
```
Error in file(filename, "r", encoding = encoding) :
  cannot open the connection
Calls: source_local -> source -> file
Warning message:
In file(filename, "r", encoding = encoding) :
  cannot open file '/jetstream/scratch0/main/jobs/32793375/tool_files/get_deseq_dataset.R': No such file or directory
```

It looks like we need Pulsar to transfer additional tool files?

Jetstream is still selectable via the job resource selector but by default if unselected, jobs will not go to Jetstream.