### PR TITLE
Bump up global output size limit

### DIFF
--- a/env/main/group_vars/galaxyservers/vars.yml
+++ b/env/main/group_vars/galaxyservers/vars.yml
@@ -116,7 +116,7 @@ galaxy_job_conf_limits:
   - type: walltime
     value: '49:00:00'
   - type: output_size
-    value: 50G
+    value: 125G
 
   # per-environments per-user limits
   - type: environment_user_concurrent_jobs


### PR DESCRIPTION
50 GB is a bit on the low side as a global limit.
Half of the regular quota size seems fine, though maybe we'd want to
make that a function the actual user quota at some point?