### PR TITLE
Add queue factor feature to job router best destination selection

### DIFF
--- a/env/common/templates/galaxy/config/job_router_conf.yml.j2
+++ b/env/common/templates/galaxy/config/job_router_conf.yml.j2
@@ -328,6 +328,10 @@ destinations:
   multi:
     - id: slurm_multi
     - id: jetstream_iu_multi
+      # jetstream can run far fewer jobs than roundup, so we weight its job count by a factor of 2 since its throughput
+      # will be lower
+      queue_factor: 2
+      # could also set threshold: on each member, default is 4
   reserved_multi:
     - id: reserved_slurm_multi
     - id: reserved_jetstream_iu_multi


### PR DESCRIPTION
Destinations with lower throughput can be weighted so that their queued job count appears higher than it is, causing more jobs to go to higher throughput destinations.