### PR TITLE
Support #training history tag

### DIFF
--- a/env/common/templates/galaxy/config/job_conf.yml.j2
+++ b/env/common/templates/galaxy/config/job_conf.yml.j2
@@ -10,6 +10,7 @@
 -#}
 
 {%- set slurm_environments = (
+    {'id': 'training', 'native_spec': '--partition=normal,jsnormal --nodes=1 --ntasks=1 --time=00:40:00 --mem=1920', 'java_mem': 1, 'create_reserved_env': false, 'create_legacy_env': false, 'tags': ['training']},
     {'id': 'normal', 'native_spec': '--partition=normal,jsnormal --nodes=1 --ntasks=1 --time=36:00:00', 'java_mem': 7, 'create_reserved_env': true, 'create_legacy_env': true, 'tags': ['normal']},
     {'id': 'normal_16gb', 'native_spec': '--partition=normal,jsnormal --nodes=1 --ntasks=1 --time=36:00:00 --mem=15360', 'java_mem': 15, 'create_reserved_env': true},
     {'id': 'normal_32gb', 'native_spec': '--partition=normal,jsnormal --nodes=1 --ntasks=1 --time=36:00:00 --mem=30720', 'java_mem': 30, 'create_reserved_env': true},

--- a/env/main/group_vars/galaxyservers/tools_conf.yml
+++ b/env/main/group_vars/galaxyservers/tools_conf.yml
@@ -6,13 +6,16 @@
 
 # this is used in the "tools" section of the job_conf - make sure any you define here don't appear in lists below
 galaxy_job_conf_tools:
-  - id: random_lines1
-    environment: tacc_k8s
-    handler: k8s
+  #- id: random_lines1
+  #  environment: tacc_k8s
+  #  handler: k8s
   - id: interactive_tool_jupyter_notebook
     environment: tacc_k8s
     handler: k8s
   - id: interactive_tool_rstudio
+    environment: tacc_k8s
+    handler: k8s
+  - id: interactive_tool_panoply
     environment: tacc_k8s
     handler: k8s
 

--- a/env/main/group_vars/galaxyservers/vars.yml
+++ b/env/main/group_vars/galaxyservers/vars.yml
@@ -135,6 +135,9 @@ galaxy_job_conf_limits:
 
   # per-environments per-user limits
   - type: environment_user_concurrent_jobs
+    id: training
+    value: 4
+  - type: environment_user_concurrent_jobs
     id: normal
     #value: 6
     value: 4

--- a/env/test/group_vars/galaxyservers/tools_conf.yml
+++ b/env/test/group_vars/galaxyservers/tools_conf.yml
@@ -6,13 +6,16 @@
 
 # this is used in the "tools" section of the job_conf - make sure any you define here don't appear in lists below
 galaxy_job_conf_tools:
-  - id: random_lines1
-    environment: tacc_k8s
-    handler: multi
+  #- id: random_lines1
+  #  environment: tacc_k8s
+  #  handler: multi
   - id: interactive_tool_jupyter_notebook
     environment: tacc_k8s
     handler: multi
   - id: interactive_tool_rstudio
+    environment: tacc_k8s
+    handler: multi
+  - id: interactive_tool_panoply
     environment: tacc_k8s
     handler: multi
 

--- a/env/test/group_vars/galaxyservers/vars.yml
+++ b/env/test/group_vars/galaxyservers/vars.yml
@@ -117,6 +117,9 @@ galaxy_job_conf_limits:
 
   # per-environments per-user limits
   - type: environment_user_concurrent_jobs
+    id: training
+    value: 4
+  - type: environment_user_concurrent_jobs
     id: normal
     value: 4
   - type: environment_user_concurrent_jobs


### PR DESCRIPTION
For training/workshops, we want fast dispatching and low resource allocations to maximize throughput. What this does:

- If you tag your history `#training` it sends all jobs (mapping, assembly, any multicore tool, you name it, anything but GxITs) to the normal partition with 1 core, 2 GB of memory, and a walltime of 40 minutes
- If you need to override the training setting for a single job in the history, for tools with the job resource selector enabled (all multicore tools) you can still use the selector (at the bottom of the tool form) to explicitly select the resource and it'll instead run on whatever compute resource you select with the regular cpu/memory/walltime
- Also, the effects of adding and removing the tag are instantaneous for any new jobs in the history so you can control it pretty easily that way