### PR TITLE
Add support for user preferences to main, test

### DIFF
--- a/env/main/files/galaxy/config/user_preferences.yml
+++ b/env/main/files/galaxy/config/user_preferences.yml
@@ -1,0 +1,25 @@
+preferences:
+    use_cached_job:
+      description: Do you want to be able to re-use previously run jobs ?
+      inputs:
+        - name: use_cached_job_checkbox
+          label: Do you want to be able to re-use  equivalent jobs ?
+          type: boolean
+          checked: false
+          value: false
+          help: If you select yes, you will be able to select for each tool and workflow run if you would like to use this feature.
+
+    localization:
+        description: Localization
+        inputs:
+            - name: locale
+              label: Prefered language
+              type: select
+              required: False
+              options:
+                  - [Navigator default, auto]
+                  - [中文, zh]
+                  - [English, en]
+                  - [Español, es]
+                  - [Français, fr]
+                  - [日本語, ja]

--- a/env/main/group_vars/galaxyservers/vars.yml
+++ b/env/main/group_vars/galaxyservers/vars.yml
@@ -337,6 +337,8 @@ galaxy_config_files:
     dest: "{{ galaxy_config[galaxy_app_config_section]['blacklist_file'] }}"
   - src: files/galaxy/config/workflow_schedulers_conf.xml
     dest: "{{ galaxy_config_dir }}/workflow_schedulers_conf.xml"
+  - src: files/galaxy/config/user_preferences.yml
+    dest: "{{ galaxy_config[galaxy_app_config_section]['user_preferences_extra_conf_path'] }}"
 
 # specifies config files to template from the playbook
 galaxy_config_templates:

--- a/env/test/files/galaxy/config/user_preferences.yml
+++ b/env/test/files/galaxy/config/user_preferences.yml
@@ -1,0 +1,25 @@
+preferences:
+    use_cached_job:
+      description: Do you want to be able to re-use previously run jobs ?
+      inputs:
+        - name: use_cached_job_checkbox
+          label: Do you want to be able to re-use  equivalent jobs ?
+          type: boolean
+          checked: false
+          value: false
+          help: If you select yes, you will be able to select for each tool and workflow run if you would like to use this feature.
+
+    localization:
+        description: Localization
+        inputs:
+            - name: locale
+              label: Prefered language
+              type: select
+              required: False
+              options:
+                  - [Navigator default, auto]
+                  - [中文, zh]
+                  - [English, en]
+                  - [Español, es]
+                  - [Français, fr]
+                  - [日本語, ja]

--- a/env/test/group_vars/all/galaxy_config_vars.yml
+++ b/env/test/group_vars/all/galaxy_config_vars.yml
@@ -129,6 +129,7 @@ base_app_main: &BASE_APP_MAIN
   integrated_tool_panel_config: "{{ galaxy_mutable_config_dir }}/integrated_tool_panel.xml"
   sanitize_whitelist_file: /galaxy-repl/test/config/sanitize_whitelist.txt
 
+  user_preferences_extra_conf_path: "{{ galaxy_config_dir }}/user_preferences.yml"
   containers_config_file: "{{ galaxy_config_dir }}/containers.yml"
   container_image_cache_path: "{{ galaxy_mutable_data_dir }}/container_images"
   enable_beta_containers_interface: "True"

--- a/env/test/group_vars/galaxyservers/vars.yml
+++ b/env/test/group_vars/galaxyservers/vars.yml
@@ -309,6 +309,8 @@ galaxy_config_files:
     dest: "{{ galaxy_config[galaxy_app_config_section]['blacklist_file'] }}"
   - src: files/galaxy/config/workflow_schedulers_conf.xml
     dest: "{{ galaxy_config_dir }}/workflow_schedulers_conf.xml"
+  - src: files/galaxy/config/user_preferences.yml
+    dest: "{{ galaxy_config[galaxy_app_config_section]['user_preferences_extra_conf_path'] }}"
 
 # specifies config files to template from the playbook
 galaxy_config_templates:


### PR DESCRIPTION
I was going to go make a screenshot for the GTN using the spanish localisation of Galaxy, but user-prefs wasn't enabled on either.

This also includes the job-caching, I'm not sure if that should be removed due to support request overhead or so.