### PR TITLE
Fix bug: paratus_aws_secret_access_key is undefined on test

### DIFF
--- a/env/test/group_vars/cvmfsstratum0servers.yml
+++ b/env/test/group_vars/cvmfsstratum0servers.yml
@@ -5,6 +5,8 @@ covid_crg_ftp_staging_user: foo
 covid_crg_ftp_staging_passwd: foo
 genomeark_galaxy_aws_secret_access_key: foo
 genomeark_galaxy_aws_access_key_id: foo
+paratus_aws_secret_access_key: foo
+paratus_aws_access_key_id: foo
 
 miniconda_prefix: /cvmfs/{{ galaxy_cvmfs_repo }}/deps/_conda
 miniconda_channels:


### PR DESCRIPTION
Fix for this:
```
changed: [cvmfs0-psu1.galaxyproject.org] => (item={'src': 'templates/galaxy/config/job_conf.yml.j2', 'dest': '/tmp/ansible_usegalaxy_cvmfs_galaxy_config_dir_Aojy9b/job_conf.yml'})
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ansible.errors.AnsibleUndefinedVariable: 'paratus_aws_secret_access_key' is undefined. 'paratus_aws_secret_access_key' is undefined
failed: [cvmfs0-psu1.galaxyproject.org] (item={'src': 'templates/galaxy/config/file_sources_conf.yml.j2', 'dest': '/tmp/ansible_usegalaxy_cvmfs_galaxy_config_dir_Aojy9b/file_sources_conf.yml'}) => {"ansible_loop_var": "item", "changed": false, "item": {"dest": "/tmp/ansible_usegalaxy_cvmfs_galaxy_config_dir_Aojy9b/file_sources_conf.yml", "src": "templates/galaxy/config/file_sources_conf.yml.j2"}, "msg": "AnsibleUndefinedVariable: 'paratus_aws_secret_access_key' is undefined. 'paratus_aws_secret_access_key' is undefined"}
```