### PR TITLE
Mark scratch object stores as non-private.

### DIFF
--- a/env/main/group_vars/all/galaxy_config_vars.yml
+++ b/env/main/group_vars/all/galaxy_config_vars.yml
@@ -140,7 +140,7 @@ base_app_main: &BASE_APP_MAIN
         weight: 0
         store_by: uuid
         allow_selection: true
-        private: true
+        private: false
         quota:
           source: scratch
         name: "Short Term Storage at TACC"

--- a/env/test/group_vars/all/galaxy_config_vars.yml
+++ b/env/test/group_vars/all/galaxy_config_vars.yml
@@ -172,7 +172,7 @@ base_app_main: &BASE_APP_MAIN
         weight: 0
         store_by: uuid
         allow_selection: true
-        private: true
+        private: false
         quota:
           source: scratch
         name: "Short Term Storage at TACC"


### PR DESCRIPTION
I'll take a pass at the UI for these but it isn't great.

Moving storage locations didn't land up depending on this also - I checked if the datasets had been copied instead which seems performant enough.