### PR TITLE
Make sure tpv shared db is loaded first

### DIFF
--- a/env/common/templates/galaxy/config/job_conf.yml.j2
+++ b/env/common/templates/galaxy/config/job_conf.yml.j2
@@ -65,7 +65,7 @@ execution:
       function: map_tool_to_destination
       rules_module: tpv.rules
       tpv_config_files:
-        - "https://gxy.io/tpv/db.yml"      
+        - "https://raw.githubusercontent.com/galaxyproject/tpv-shared-database/e2277c4e9aa8044342832f08d9fc06ebf7e8287c/tools.yml"
         - "{{ tpv_config_dir }}/defaults.yaml"
         - "{{ tpv_config_dir }}/environments.yaml"
         - "{{ tpv_config_dir }}/tools_pre_shared.yaml"

--- a/env/common/templates/galaxy/config/job_conf.yml.j2
+++ b/env/common/templates/galaxy/config/job_conf.yml.j2
@@ -65,10 +65,10 @@ execution:
       function: map_tool_to_destination
       rules_module: tpv.rules
       tpv_config_files:
+        - "https://gxy.io/tpv/db.yml"      
         - "{{ tpv_config_dir }}/defaults.yaml"
         - "{{ tpv_config_dir }}/environments.yaml"
         - "{{ tpv_config_dir }}/tools_pre_shared.yaml"
-        - "https://raw.githubusercontent.com/galaxyproject/tpv-shared-database/main/tools.yml"
         - "{{ tpv_config_dir }}/tools.yaml"
         - "{{ tpv_config_dir }}/users.yaml"
         - "{{ tpv_config_dir }}/roles.yaml"

--- a/env/main/templates/galaxy/config/job_conf_vgp.yml.j2
+++ b/env/main/templates/galaxy/config/job_conf_vgp.yml.j2
@@ -73,9 +73,9 @@ execution:
       function: map_tool_to_destination
       rules_module: tpv.rules
       tpv_config_files:
+        - "https://gxy.io/tpv/db.yml"
         - "{{ tpv_config_dir }}/defaults_vgp.yaml"
         - "{{ tpv_config_dir }}/environments_vgp.yaml"
-        - "https://raw.githubusercontent.com/galaxyproject/tpv-shared-database/main/tools.yml"
         - "{{ tpv_config_dir }}/tools_vgp.yaml"
         #- "{{ tpv_config_dir }}/users_vgp.yaml"
         - "{{ tpv_config_dir }}/roles_vgp.yaml"

--- a/env/main/templates/galaxy/config/job_conf_vgp.yml.j2
+++ b/env/main/templates/galaxy/config/job_conf_vgp.yml.j2
@@ -73,7 +73,7 @@ execution:
       function: map_tool_to_destination
       rules_module: tpv.rules
       tpv_config_files:
-        - "https://gxy.io/tpv/db.yml"
+        - "https://raw.githubusercontent.com/galaxyproject/tpv-shared-database/e2277c4e9aa8044342832f08d9fc06ebf7e8287c/tools.yml"
         - "{{ tpv_config_dir }}/defaults_vgp.yaml"
         - "{{ tpv_config_dir }}/environments_vgp.yaml"
         - "{{ tpv_config_dir }}/tools_vgp.yaml"


### PR DESCRIPTION
The reason for the drama with overriding is because of the loading order, causing the tpv shared db to override local config, instead of local config always overriding the shared db. This fixes that, and also uses the short url for the shared db. Just in case, I've added some extra tests for overriding default inheritance that simulates main pretty closely: https://github.com/galaxyproject/total-perspective-vortex/pull/132

I've also made a PR restoring the original changes to the tpv shared db: https://github.com/galaxyproject/tpv-shared-database/pull/63.