### PR TITLE
Add user perf for chat-analysis tool

### DIFF
--- a/env/main/files/galaxy/config/user_preferences.yml
+++ b/env/main/files/galaxy/config/user_preferences.yml
@@ -44,7 +44,7 @@ preferences:
               label: OpenAI API Key
               type: password
               required: False
-      groq:
+    groq:
         description: Groq
         inputs:
             - name: api_key

--- a/env/main/files/galaxy/config/user_preferences.yml
+++ b/env/main/files/galaxy/config/user_preferences.yml
@@ -37,3 +37,17 @@ preferences:
               type: text
               required: False
               value: https://auth.quantum-computing.ibm.com/api
+    chatgpt:
+        description: ChatGPT
+        inputs:
+            - name: api_key
+              label: OpenAI API Key
+              type: password
+              required: False
+      groq:
+        description: Groq
+        inputs:
+            - name: api_key
+              label: Groq API Key
+              type: password
+              required: False


### PR DESCRIPTION
For [deploying the chat-analysis tool to the main Galaxy instance](https://github.com/galaxyproject/usegalaxy-tools/pull/881/commits/21d9151bb472f6fa65cdaefe8a4180f365974fa4), we will need to add two user preferences: the GPT API key and the Groq API key.

The [code](https://github.com/goeckslab/ChatAnalysis/blob/2d72b2974a22a70ca07ed81baaa01e9ade8c1acc/tools/chat_analysis.xml#L34) in the GitHub repository for the chat-analysis app provides references on why these two user preferences are necessary.