### PR TITLE
Test new image, proxied

### DIFF
--- a/env/common/templates/galaxy/config/tpv/tools.yaml.j2
+++ b/env/common/templates/galaxy/config/tpv/tools.yaml.j2
@@ -231,7 +231,7 @@ tools:
       container_override:
       - type: docker
         shell: /bin/bash
-        identifier: quay.io/natefoo/docker-rstudio-notebook:23.1-proxy1
+        identifier: afgane/bioc-galaxy:3.20-proxy1
 
   toolshed.g2.bx.psu.edu/repos/goeckslab/chatanalysis/interactive_tool_chat_analysis/.*:
     params:


### PR DESCRIPTION
This modifies the default bioc image with files from here https://github.com/hexylena/docker-rstudio-notebook/compare/main...natefoo:docker-rstudio-notebook:23.1-proxy

Works locally but not sure if there's a lighter weight way to test on Test?