### PR TITLE
Change one user preference name from chatgpt to openai

### DIFF
--- a/env/main/files/galaxy/config/user_preferences.yml
+++ b/env/main/files/galaxy/config/user_preferences.yml
@@ -37,8 +37,8 @@ preferences:
               type: text
               required: False
               value: https://auth.quantum-computing.ibm.com/api
-    chatgpt:
-        description: ChatGPT
+    openai:
+        description: OPENAI
         inputs:
             - name: api_key
               label: OpenAI API Key


### PR DESCRIPTION
Change 'ChatGPT' to 'OpenAI' for consistency with the OpenAI API key naming.