### PR TITLE
Store tpv_cores, mem and gpus for analysis purposes

### DIFF
--- a/env/common/templates/galaxy/config/tpv/defaults.yaml.j2
+++ b/env/common/templates/galaxy/config/tpv/defaults.yaml.j2
@@ -21,6 +21,10 @@ tools:
       time: null
       default_time: "36:00:00"
       xdg_cache_home: null
+    params:
+      tpv_cores: '{cores}'
+      tpv_gpus: '{gpus}'
+      tpv_mem: '{mem}'
     env:
     - execute: ulimit -c 0
     # tools in the shared DB override this, which then breaks some tools, so set on the destinations instead for


### PR DESCRIPTION
The tpv shared database stores adds the following params to make it easier to analyse metrics:
```
    params:
      tpv_cores: '{cores}'
      tpv_gpus: '{gpus}'
      tpv_mem: '{mem}'
```
Otherwise, you have to reverse engineer it from the destination params using some complicated SQL:
```
                COALESCE(
                    -- Attempt to calculate memory from mem-per-cpu multiplied by the number of cores
                    CAST(SUBSTRING(encode(j.destination_params, 'escape') FROM 'mem-per-cpu=(\d+)') AS NUMERIC)
                    * CAST(SUBSTRING(encode(j.destination_params, 'escape') FROM 'ntasks=(\d+)') AS NUMERIC),
                    -- Fallback to regular mem if mem-per-cpu is not found
                    CAST(SUBSTRING(encode(j.destination_params, 'escape') FROM 'mem=(\d+)') AS NUMERIC)
                )/1024.0 as tpv_mem_gb,
```

In the same go, it would be great if main could use the default from the tpv-shared-db. I think the original reasons for having a different _default are no longer an issue.