### PR TITLE
TPV: route user-defined tools to isolated pulsar destination

### DIFF
--- a/env/common/templates/galaxy/config/tpv/environments.yaml.j2
+++ b/env/common/templates/galaxy/config/tpv/environments.yaml.j2
@@ -387,9 +387,8 @@ destinations:
       submit_native_specification: "--nodes=1 --ntasks={int(cores)} --mem={int(mem*1024)} --time={time or default_time} --partition={js2_partition}"
       require_container: true
     scheduling:
-      accept:
-      - tool_type_user_defined
       require:
+      - tool_type_user_defined
       - pulsar
       - singularity
 

--- a/env/common/templates/galaxy/config/tpv/environments.yaml.j2
+++ b/env/common/templates/galaxy/config/tpv/environments.yaml.j2
@@ -372,6 +372,26 @@ destinations:
       #reject:
       #- offline
 
+  # User-defined tools (created via the Galaxy tool builder UI). Isolated:
+  # mandatory container, no host networking. Only matched via the
+  # `tool_type_user_defined` tag set on the user_defined-.* tool rule.
+  jetstream2_user_defined:
+    inherits: _jetstream2
+    min_accepted_cores: 1
+    min_accepted_mem: 0
+    max_accepted_cores: 16
+    max_accepted_mem: 60
+    params:
+      submit_native_specification: "--nodes=1 --ntasks={int(cores)} --mem={int(mem*1024)} --time={time or default_time} --partition={js2_partition}"
+      require_container: true
+      singularity_run_extra_arguments: "--net --network none"
+    scheduling:
+      accept:
+      - tool_type_user_defined
+      require:
+      - pulsar
+      - singularity
+
   jetstream2_gxit:
     runner: jetstream2
     min_accepted_cores: 1

--- a/env/common/templates/galaxy/config/tpv/environments.yaml.j2
+++ b/env/common/templates/galaxy/config/tpv/environments.yaml.j2
@@ -372,9 +372,11 @@ destinations:
       #reject:
       #- offline
 
-  # User-defined tools (created via the Galaxy tool builder UI). Isolated:
-  # mandatory container, no host networking. Only matched via the
-  # `tool_type_user_defined` tag set on the user_defined-.* tool rule.
+  # User-defined tools (created via the Galaxy tool builder UI). Mandatory
+  # containerization; only matched via the `tool_type_user_defined` tag set
+  # on the user_defined-.* tool rule. Note: apptainer's `--network none`
+  # requires root/setuid, so we do not attempt in-container network
+  # isolation here — rely on container + host network policy.
   jetstream2_user_defined:
     inherits: _jetstream2
     min_accepted_cores: 1
@@ -384,7 +386,6 @@ destinations:
     params:
       submit_native_specification: "--nodes=1 --ntasks={int(cores)} --mem={int(mem*1024)} --time={time or default_time} --partition={js2_partition}"
       require_container: true
-      singularity_run_extra_arguments: "--net --network none"
     scheduling:
       accept:
       - tool_type_user_defined

--- a/env/common/templates/galaxy/config/tpv/tools.yaml.j2
+++ b/env/common/templates/galaxy/config/tpv/tools.yaml.j2
@@ -254,18 +254,16 @@ tools:
         shell: /bin/sh
         identifier: /cvmfs/main.galaxyproject.org/singularity/bioc-galaxy:3.21.live.2
 
-  # user-defined tools (Galaxy tool builder / DynamicTool). The TPV mapper
-  # looks them up under id `{tool_type}-{uuid}` (tpv/core/mapper.py); the
-  # `tool_provided_resources_<uuid>` id surfaced in errors is a synthetic
-  # entity TPV builds to expose UDT resource requirements.
+  # user-defined tools (Galaxy tool builder / DynamicTool).
+  # Routing/isolation is handled automatically by current TPV:
+  #   - the synthesized tool entity gets `accept: tool_type_user_defined`
+  #     (tpv/core/mapper.py: __get_environment_inherits)
+  #   - all destinations inherit a synthesized `reject: tool_type_user_defined`
+  #     unless they explicitly opt in via `accept` (jetstream2_user_defined).
+  # We only need to set sensible resource defaults and gate on login.
   user_defined-.*:
     cores: 1
     mem: 3.7
-    scheduling:
-      require:
-      - tool_type_user_defined
-      - pulsar
-      - singularity
     rules:
     - id: require_login_user_defined
       if: user is None

--- a/env/common/templates/galaxy/config/tpv/tools.yaml.j2
+++ b/env/common/templates/galaxy/config/tpv/tools.yaml.j2
@@ -254,6 +254,23 @@ tools:
         shell: /bin/sh
         identifier: /cvmfs/main.galaxyproject.org/singularity/bioc-galaxy:3.21.live.2
 
+  # user-defined tools (Galaxy tool builder / DynamicTool). The TPV mapper
+  # looks them up under id `{tool_type}-{uuid}` (tpv/core/mapper.py); the
+  # `tool_provided_resources_<uuid>` id surfaced in errors is a synthetic
+  # entity TPV builds to expose UDT resource requirements.
+  user_defined-.*:
+    cores: 1
+    mem: 3.7
+    scheduling:
+      require:
+      - tool_type_user_defined
+      - pulsar
+      - singularity
+    rules:
+    - id: require_login_user_defined
+      if: user is None
+      fail: An account is required to run this tool. Please log in or create an account.
+
   # interactive tools
 
   .*interactive_tool_.*:


### PR DESCRIPTION
UDTs (Galaxy tool builder) were rejected on Test with "No destinations are available to fulfill request: tool_provided_resources_<uuid>" because no tool rule matched the `user_defined-<uuid>` id TPV uses for lookup.

Add a dedicated `jetstream2_user_defined` destination (pulsar + singularity, require_containere) and a `user_defined-.*` tool rule that pins UDTs to it via a `tool_type_user_defined` tag, keeping untrusted user code off destinations used by trusted tools.