### PR TITLE
Add Machine Learning panel group

### DIFF
--- a/env/main/files/galaxy/config/panel_views/all_tools.yml
+++ b/env/main/files/galaxy/config/panel_views/all_tools.yml
@@ -59,9 +59,15 @@ items:
   type: label
 - sections:
   - statistics
-  - machine_learning
   - graph_display_data
   - interactive_tools
+- id: machine_learning_label
+  text: Machine Learning
+  type: label
+- sections:
+  - classical_ml_and_automl
+  - deep_learning
+  - multi_omics_ml
 - id: genomics_toolkits_label
   text: Genomics Toolkits
   type: label

--- a/env/main/files/galaxy/config/panel_views/imaging.yml
+++ b/env/main/files/galaxy/config/panel_views/imaging.yml
@@ -20,9 +20,15 @@ items:
   type: label
 - sections:
   - statistics
-  - machine_learning
   - graph_display_data
   - interactive_tools
+- id: machine_learning_label
+  text: Machine Learning
+  type: label
+- sections:
+  - classical_ml_and_automl
+  - deep_learning
+  - multi_omics_ml
 - id: imaging_label
   text: Imaging
   type: label

--- a/env/main/files/galaxy/config/tool_conf.xml
+++ b/env/main/files/galaxy/config/tool_conf.xml
@@ -150,7 +150,6 @@
     <tool file="stats/gsummary.xml" />
     <tool file="filters/uniq.xml" />
   </section>
-  <section id="machine_learning" name="Machine Learning"/>
   <section id="graph_display_data" name="Graph/Display Data">
     <tool file="plotting/boxplot.xml" hidden="true" />
     <tool file="plotting/bar_chart.xml" hidden="true" />
@@ -166,5 +165,9 @@
     <tool file="interactive/interactivetool_blobtoolkit.xml" />
     <tool file="interactive/interactivetool_rstudio_bioc_3.20.xml" hidden="true" />
   </section>
+  <label id="machine_learning_label" text="Machine Learning" />
+  <section id="classical_ml_and_automl" name="Classical ML and AutoML"/>
+  <section id="deep_learning" name="Deep Learning"/>
+  <section id="multi_omics_ml" name="Multi-omics ML"/>
   <label id="miscellaneous_tools_label" text="Miscellaneous Tools" />
 </toolbox>


### PR DESCRIPTION
## Summary
- Move Machine Learning out from under the Statistics and Visualization group in the Main tool panel layout.
- Add a dedicated Machine Learning header with Classical ML and AutoML, Deep Learning, and Multi-omics ML sections.
- Update the All Tools and Imaging panel views to reference the new section IDs.

## Companion PR
- usegalaxy-tools install-list companion PR: https://github.com/galaxyproject/usegalaxy-tools/pull/1512
- This PR provides the UI placement for the new sections introduced there and should be merged together with it.

## Validation
- Parsed env/main/files/galaxy/config/tool_conf.xml as XML.
- Parsed env/main/files/galaxy/config/panel_views/all_tools.yml and imaging.yml as YAML.
- git diff --check.