### PR TITLE
Drop dead symlink

### DIFF
--- a/env/main/files/ssl
+++ b/env/main/files/ssl
@@ -1,1 +1,0 @@
-../../common/files/ssl


### PR DESCRIPTION
Target deleted in commit 6ffdcb7 on May 24, 2024 ("Drop remaining Tool Shed stuff moved to infrastructure-playbook")