### PR TITLE
Remove dead symlinks

### DIFF
--- a/env/main/files/galaxy/error
+++ b/env/main/files/galaxy/error
@@ -1,1 +1,0 @@
-../../../common/files/galaxy/error

--- a/env/main/templates/galaxy/files
+++ b/env/main/templates/galaxy/files
@@ -1,1 +1,0 @@
-../../../common/templates/galaxy/files

--- a/env/test/templates/galaxy/files
+++ b/env/test/templates/galaxy/files
@@ -1,1 +1,0 @@
-../../../common/templates/galaxy/files


### PR DESCRIPTION
These symlinks point to targets that no longer exist (env/common/files/galaxy/error was deleted, and env/common/templates/galaxy/files was never present), and are not referenced by any playbook or task.

Note: there are other dead symlinks which are not really "dead": those point to files in roles to be installed.