### PR TITLE
Add cached_explicit_singularity resolver for biocontainers CVMFS cache

### DIFF
--- a/env/common/templates/galaxy/config/tpv/environments.yaml.j2
+++ b/env/common/templates/galaxy/config/tpv/environments.yaml.j2
@@ -139,6 +139,10 @@ destinations:
       singularity_volumes: "{{ galaxy_job_conf_singularity_volumes.tacc_hpc | join(',') }}"
       singularity_no_mount: null
       container_resolvers:
+      - type: cached_explicit_singularity
+        cache_directory: /cvmfs/singularity.galaxyproject.org/all
+        namespace: biocontainers
+        cache_directory_cacher_type: dir_mtime
       - type: explicit_singularity
       - type: cached_mulled_singularity
         cache_directory: /cvmfs/singularity.galaxyproject.org/all
@@ -492,6 +496,10 @@ destinations:
       singularity_no_mount: null
       #singularity_cmd: $CVMFSEXEC_PATH -N data.galaxyproject.org brc.galaxyproject.org vgp.galaxyproject.org singularity.galaxyproject.org -- singularity
       container_resolvers:
+      - type: cached_explicit_singularity
+        cache_directory: /cvmfs/singularity.galaxyproject.org/all
+        namespace: biocontainers
+        cache_directory_cacher_type: dir_mtime
       - type: explicit_singularity
       - type: cached_mulled_singularity
         cache_directory: /cvmfs/singularity.galaxyproject.org/all
@@ -567,6 +575,10 @@ destinations:
       #singularity_cmd: $CVMFSEXEC_PATH -N data.galaxyproject.org brc.galaxyproject.org vgp.galaxyproject.org singularity.galaxyproject.org oasis.opensciencegrid.org -- /cvmfs/oasis.opensciencegrid.org/mis/apptainer/bin/apptainer
       singularity_no_mount: null
       container_resolvers:
+      - type: cached_explicit_singularity
+        cache_directory: /cvmfs/singularity.galaxyproject.org/all
+        namespace: biocontainers
+        cache_directory_cacher_type: dir_mtime
       - type: explicit_singularity
       - type: cached_mulled_singularity
         cache_directory: /cvmfs/singularity.galaxyproject.org/all
@@ -643,6 +655,10 @@ destinations:
       singularity_volumes: "{{ galaxy_job_conf_singularity_volumes.anvil | join(',') }}"
       singularity_no_mount: null
       container_resolvers:
+      - type: cached_explicit_singularity
+        cache_directory: /cvmfs/singularity.galaxyproject.org/all
+        namespace: biocontainers
+        cache_directory_cacher_type: dir_mtime
       - type: explicit_singularity
       - type: cached_mulled_singularity
         cache_directory: /cvmfs/singularity.galaxyproject.org/all

--- a/env/common/templates/galaxy/config/tpv/environments_vgp.yaml.j2
+++ b/env/common/templates/galaxy/config/tpv/environments_vgp.yaml.j2
@@ -210,6 +210,10 @@ destinations:
       singularity_no_mount: null
       singularity_cmd: $CVMFSEXEC_PATH -N data.galaxyproject.org brc.galaxyproject.org vgp.galaxyproject.org singularity.galaxyproject.org -- apptainer
       container_resolvers:
+      - type: cached_explicit_singularity
+        cache_directory: /cvmfs/singularity.galaxyproject.org/all
+        namespace: biocontainers
+        cache_directory_cacher_type: dir_mtime
       - type: explicit_singularity
       - type: cached_mulled_singularity
         cache_directory: /cvmfs/singularity.galaxyproject.org/all

--- a/env/main/group_vars/all/galaxy_config_vars.yml
+++ b/env/main/group_vars/all/galaxy_config_vars.yml
@@ -293,6 +293,10 @@ base_app_main: &BASE_APP_MAIN
       versionless: true
 
   container_resolvers:
+    - type: cached_explicit_singularity
+      cache_directory: /cvmfs/singularity.galaxyproject.org/all
+      namespace: biocontainers
+      cache_directory_cacher_type: dir_mtime
     - type: cached_mulled_singularity
       cache_directory: /cvmfs/singularity.galaxyproject.org/all
       cache_directory_cacher_type: dir_mtime

--- a/env/main/host_vars/galaxy-vgp.tacc.utexas.edu/vars.yml
+++ b/env/main/host_vars/galaxy-vgp.tacc.utexas.edu/vars.yml
@@ -290,6 +290,10 @@ galaxy_config_hash:
         versionless: true
 
     container_resolvers:
+      - type: cached_explicit_singularity
+        cache_directory: /cvmfs/singularity.galaxyproject.org/all
+        namespace: biocontainers
+        cache_directory_cacher_type: dir_mtime
       - type: cached_mulled_singularity
         cache_directory: /cvmfs/singularity.galaxyproject.org/all
         cache_directory_cacher_type: dir_mtime

--- a/env/test/files/galaxy/config/container_resolvers_conf.yml
+++ b/env/test/files/galaxy/config/container_resolvers_conf.yml
@@ -1,6 +1,10 @@
 ---
 
 #- type: explicit
+- type: cached_explicit_singularity
+  cache_directory: /cvmfs/singularity.galaxyproject.org/all
+  namespace: biocontainers
+  cache_directory_cacher_type: dir_mtime
 - type: cached_mulled_singularity
   cache_directory: /cvmfs/singularity.galaxyproject.org/all
   cache_directory_cacher_type: dir_mtime


### PR DESCRIPTION
## Summary

- Adds `cached_explicit_singularity` resolver (galaxyproject/galaxy#22878) before `explicit_singularity` in all eligible container resolver configs
- Uses `cache_directory: /cvmfs/singularity.galaxyproject.org/all`, `namespace: biocontainers`, and `cache_directory_cacher_type: dir_mtime`
- Strips `docker://quay.io/biocontainers/` prefix from explicit container specs and looks up flat filenames in the CVMFS cache before falling back to pulling

## Eligible destinations (have singularity.galaxyproject.org accessible)

- **cyclone / jetstream2** — native CVMFS (via global config)
- **tacc_hpc** (stampede3, stampede3_skx, frontera) — cvmfsexec `singularity.galaxyproject.org`
- **bridges2, expanse, anvil** — cvmfsexec `mountrepo singularity.galaxyproject.org`
- **stampede3_nvdimm** (VGP) — cvmfsexec `singularity.galaxyproject.org`

## Not updated

- `rockfish_devgalaxy` — no CVMFS singularity mount
- `frontera_rtx` — `singularity_volumes: null`, no cached resolvers by design