### PR TITLE
Use TPV auto-injected resource requirements for UDTs

### DIFF
--- a/env/common/templates/galaxy/config/tpv/tools.yaml.j2
+++ b/env/common/templates/galaxy/config/tpv/tools.yaml.j2
@@ -269,10 +269,10 @@ tools:
       if: user is None
       fail: An account is required to run this tool. Please log in or create an account.
     - id: udt_gpu_access
-      if: gpus is not None and gpus > 0 and not any(role.name == 'GPU Access' and not role.deleted for role in user.all_roles())
+      if: entity.gpus is not None and entity.gpus > 0 and not any(role.name == 'GPU Access' and not role.deleted for role in user.all_roles())
       fail: GPU access is not authorized for your account. Please request the "GPU Access" role.
     - id: udt_gpu_routing
-      if: gpus is not None and gpus > 0
+      if: entity.gpus is not None and entity.gpus > 0
       scheduling:
         require:
         - gpu

--- a/env/common/templates/galaxy/config/tpv/tools.yaml.j2
+++ b/env/common/templates/galaxy/config/tpv/tools.yaml.j2
@@ -268,47 +268,11 @@ tools:
     - id: require_login_user_defined
       if: user is None
       fail: An account is required to run this tool. Please log in or create an account.
-    - id: anton_udt_8c
-      if: user.email == "anton@bx.psu.edu" and tool.id.startswith("anton-8-")
-      cores: 8
-      mem: 28
-    - id: anton_udt_32c
-      if: user.email == "anton@bx.psu.edu" and tool.id.startswith("anton-32-")
-      cores: 32
-      mem: 120
-    - id: anton_udt_gpu_medium
-      if: user.email == "anton@bx.psu.edu" and tool.id.startswith("anton-gpu-medium-")
-      cores: 8
-      mem: 28
-      gpus: 0.25
+    - id: udt_gpu_routing
+      if: gpus is not None and gpus > 0
       scheduling:
         require:
         - gpu
-    - id: anton_udt_gpu_large
-      if: user.email == "anton@bx.psu.edu" and tool.id.startswith("anton-gpu-large-")
-      cores: 16
-      mem: 58
-      gpus: 0.5
-      scheduling:
-        require:
-        - gpu
-    - id: anton_udt_gpu_xl
-      if: user.email == "anton@bx.psu.edu" and tool.id.startswith("anton-gpu-xl-")
-      cores: 32
-      mem: 118
-      gpus: 1
-      scheduling:
-        require:
-        - gpu
-    #- id: user_is_anton
-    #  if: user.email == "anton@bx.psu.edu"
-    #  #cores: 8
-    #  env:
-    #  - name: GALAXY_SLOTS
-    #    value: "8"
-    #  scheduling:
-    #    require:
-    #    - anton
 
   # interactive tools
 

--- a/env/common/templates/galaxy/config/tpv/tools.yaml.j2
+++ b/env/common/templates/galaxy/config/tpv/tools.yaml.j2
@@ -268,6 +268,9 @@ tools:
     - id: require_login_user_defined
       if: user is None
       fail: An account is required to run this tool. Please log in or create an account.
+    - id: udt_gpu_access
+      if: gpus is not None and gpus > 0 and not any(role.name == 'GPU Access' and not role.deleted for role in user.all_roles())
+      fail: GPU access is not authorized for your account. Please request the "GPU Access" role.
     - id: udt_gpu_routing
       if: gpus is not None and gpus > 0
       scheduling:


### PR DESCRIPTION
## Summary

- Replaces 5 hardcoded per-user/per-prefix TPV rules (gated on `user.email == "anton@bx.psu.edu"` + tool ID prefix) with a single `udt_gpu_routing` rule
- Cores, mem, and gpus are now sourced from the tool's `resource_requirements` XML via [TPV auto-injection](https://total-perspective-vortex.readthedocs.io/en/latest/topics/advanced_topics.html#auto-injected-tool-resource-requirements)
- The only explicit rule needed is adding the `gpu` scheduling tag when `gpus > 0`, so jobs route to GPU destinations

## Test plan

- [ ] Verify a UDT with `resource_requirements` declaring `cuda_device_count_min` routes to a GPU destination
- [ ] Verify a UDT without GPU requirements continues to route to the standard user-defined destination
- [ ] Verify unauthenticated users are still rejected